### PR TITLE
`func_specializations` include types in MethodTable backedges

### DIFF
--- a/src/LookingGlass.jl
+++ b/src/LookingGlass.jl
@@ -97,7 +97,7 @@ Backedges on a function's MethodTable means changes to _any methods_ (including 
 a method) will trigger recompilation of the target function.
 """
 function func_backedges(f)
-    out = Dict{Tuple, Vector{Any}}(
+    out = Dict{Tuple{Any,Type}, Vector{Any}}(
         # Method backedges
         k => try s.func.backedges catch ; [] end
         for (k,s) in func_specializations(f)


### PR DESCRIPTION
This now returns `(:MethodTable, Type{...})` for the backedges of a
function:

```julia
julia> LookingGlass.func_backedges(foo)
Dict{Tuple,Array{Any,1}} with 2 entries:
  (foo(x) in Main at none:1, Tuple{typeof(foo),Int64}) => Any[]
  (:MethodTable, Tuple{typeof(foo),Int64,Int64})       => Any[MethodInstance for static_hasmethod(::typeof(fo…
```