### PR TITLE
Add `LookingGlass.module_recursive_globals(m::Module)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LookingGlass"
 uuid = "1fcbbee2-b350-4a01-aad8-439064dba09e"
 authors = ["Nathan Daly"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/LookingGlass.jl
+++ b/src/LookingGlass.jl
@@ -236,6 +236,18 @@ Return a Dict mapping the name to the value of all global variables in Module `m
 """
 module_globals(m::Module) = Dict(n => Core.eval(m, n) for n in module_globals_names(m))
 
+"""
+    module_recursive_globals(m::Module) -> Dict{Tuple{Module,Symbol}, Any}
+Return a Dict mapping the fully qualified name to the value of all global variables in
+Module `m` and all its recursive submodules.
+"""
+function module_recursive_globals(m::Module)
+    return Dict((mod,n) => Core.eval(mod, n)
+                for (mod,names) in module_recursive_globals_names(m)
+                for n in names
+                )
+end
+
 function _isconst_global(m::Module, s::Symbol)
     b = _getbinding(m,s)
     b != nothing && b.constp

--- a/test/LookingGlass.jl
+++ b/test/LookingGlass.jl
@@ -50,3 +50,13 @@ end
         MV => sort([]),
         MV.Inner => sort([:i_vec]),
         )
+
+@test LookingGlass.module_recursive_globals(MV) ==
+    Dict(
+        (MV, :gv) => MV.gv,
+        (MV, :cv) => MV.cv,
+        (MV, :vec) => MV.vec,
+        (MV.Inner, :i_x) => MV.Inner.i_x,
+        (MV.Inner, :i_c) => MV.Inner.i_c,
+        (MV.Inner, :i_vec) => MV.Inner.i_vec,
+        )


### PR DESCRIPTION
Add `LookingGlass.module_recursive_globals(m::Module)`.

Example:

```julia
julia> LookingGlass.module_recursive_globals(Base)
Dict{Tuple{Module, Symbol}, Any} with 1376 entries:
  (Base, :ℯ)                                      => ℯ
  (Base, :uvhandles)                              => IdDict{Any, Any}(FileMonitor(Ptr{Nothing} @0x00007fe595bfd020, "/Users/nathandaly/.julia/dev/LookingGl…
  (Core.Compiler, :BitSigned64)                   => Union{Int16, Int32, Int64, Int8}
  (Base.IteratorsMD, :cartindexhash_seed)         => 0xd60ca92f8284b8b0
  (Base, :UV_RANDOM)                              => 10
  (Base.Unicode, :UTF8PROC_CATEGORY_LM)           => 4
  (Base.FastMath, :FloatTypes)                    => Union{Float16, Float32, Float64}
  (Base, :UV_ELOOP)                               => -62
  (Base.BinaryPlatforms.CPUID, :JL_X86_wbnoinvd)  => 0x00000109
  ⋮                                               => ⋮
```
