### PR TITLE
Add `kwargs...` to `module_recursive_globals()`, to allow imported modules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LookingGlass"
 uuid = "1fcbbee2-b350-4a01-aad8-439064dba09e"
 authors = ["Nathan Daly"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/LookingGlass.jl
+++ b/src/LookingGlass.jl
@@ -282,7 +282,9 @@ end
 Return a list of the names of all global variables for each submodule in Module `m`.
 
 Defaults to all globals, can toggle only const-globals or nonconst-globals via keyword args.
-See [`module_recursive_globals`](@ref).
+See Also:
+- [`module_globals`](@ref)
+- [`module_recursive_globals`](@ref)
 """
 module_recursive_globals_names(m::Module; constness=:all, mutability=:all, kwargs...) =
     merge!(
@@ -291,7 +293,7 @@ module_recursive_globals_names(m::Module; constness=:all, mutability=:all, kwarg
             sm => names
             for sm in module_submodules(m; recursive=true, kwargs...)
             for names in (module_globals_names(sm; constness=constness, mutability=mutability, kwargs...),)
-            if !isempty(names)
+            #if !isempty(names)
         ))
 
 """

--- a/src/LookingGlass.jl
+++ b/src/LookingGlass.jl
@@ -158,7 +158,7 @@ function _module_recursive_submodules(m; base, seen, kwargs...)
         push!(seen, m)
     end
     modules = collect(Iterators.flatten(
-        [x, _module_recursive_submodules(x, base=base, seen=seen)...]
+        [x, _module_recursive_submodules(x; base=base, seen=seen, kwargs...)...]
             for x in submodules
         ))
     return modules

--- a/test/LookingGlass.jl
+++ b/test/LookingGlass.jl
@@ -27,19 +27,22 @@ end
     @test length(first(LookingGlass.func_backedges(MF.foo))[2]) == 1
 end
 
+module Outer
+    const g_outer = 1
+end
 module MV
     gv = 2
     const cv = 2
     vec = []
     module A
-        g_a = 1
+        const g_a = 1
     end
     module Inner
         i_x = 3
         const i_c = 2
         const i_vec = [2]
 
-        import ..A
+        import ...Outer
     end
 end
 
@@ -51,11 +54,20 @@ end
         )
 
 @test LookingGlass.module_recursive_globals_names(MV,
-                     constness=:const, mutability=:mutable) ==
+                     constness = :const, mutability = :mutable) ==
     Dict(
         MV => sort([]),
         MV.Inner => sort([:i_vec]),
         MV.A => sort([]),
+        )
+
+@test LookingGlass.module_recursive_globals_names(MV,
+                     constness = :const, imported = true) ==
+    Dict(
+        MV => sort([:cv]),
+        MV.Inner => sort([:i_c, :i_vec]),
+        MV.A => sort([:g_a]),
+        Outer => sort([:g_outer]),  # imported via MV.Inner
         )
 
 @test LookingGlass.module_recursive_globals(MV) ==
@@ -78,5 +90,14 @@ end
         (MV.Inner, :i_c) => MV.Inner.i_c,
         (MV.Inner, :i_vec) => MV.Inner.i_vec,
         (MV.A, :g_a) => MV.A.g_a,
-        (MV.Inner.A, :g_a) => MV.Inner.A.g_a,
+        (Outer, :g_outer) => MV.Inner.Outer.g_outer,  # imported via MV.Inner
+        )
+
+@test LookingGlass.module_recursive_globals(MV, imported=true, constness=:const) ==
+    Dict(
+        (MV, :cv) => MV.cv,
+        (MV.Inner, :i_c) => MV.Inner.i_c,
+        (MV.Inner, :i_vec) => MV.Inner.i_vec,
+        (MV.A, :g_a) => MV.A.g_a,
+        (Outer, :g_outer) => MV.Inner.Outer.g_outer,  # imported via MV.Inner
         )

--- a/test/LookingGlass.jl
+++ b/test/LookingGlass.jl
@@ -31,10 +31,15 @@ module MV
     gv = 2
     const cv = 2
     vec = []
+    module A
+        g_a = 1
+    end
     module Inner
         i_x = 3
         const i_c = 2
         const i_vec = [2]
+
+        import ..A
     end
 end
 
@@ -42,6 +47,7 @@ end
     Dict(
         MV => sort([:gv, :cv, :vec]),
         MV.Inner => sort([:i_x, :i_c, :i_vec]),
+        MV.A => sort([:g_a]),
         )
 
 @test LookingGlass.module_recursive_globals_names(MV,
@@ -59,4 +65,17 @@ end
         (MV.Inner, :i_x) => MV.Inner.i_x,
         (MV.Inner, :i_c) => MV.Inner.i_c,
         (MV.Inner, :i_vec) => MV.Inner.i_vec,
+        (MV.A, :g_a) => MV.A.g_a,
+        )
+
+@test LookingGlass.module_recursive_globals(MV, imported=true) ==
+    Dict(
+        (MV, :gv) => MV.gv,
+        (MV, :cv) => MV.cv,
+        (MV, :vec) => MV.vec,
+        (MV.Inner, :i_x) => MV.Inner.i_x,
+        (MV.Inner, :i_c) => MV.Inner.i_c,
+        (MV.Inner, :i_vec) => MV.Inner.i_vec,
+        (MV.A, :g_a) => MV.A.g_a,
+        (MV.Inner.A, :g_a) => MV.Inner.A.g_a,
         )

--- a/test/LookingGlass.jl
+++ b/test/LookingGlass.jl
@@ -55,6 +55,7 @@ end
     Dict(
         MV => sort([]),
         MV.Inner => sort([:i_vec]),
+        MV.A => sort([]),
         )
 
 @test LookingGlass.module_recursive_globals(MV) ==


### PR DESCRIPTION
Add `kwargs...` to `module_recursive_globals()`, to allow imported modules

```julia
julia> module TestMod42092
       module M1
           const m1_x = 1
           export m1_x
       end
       module M2
           const m2_x = 1
           export m2_x
       end
       module A
           module B
               f(x) = 1
               secret = 1
               module Inner2 end
           end
           module C
               x = 1
               y = 2
               export y
           end
           using .B: f
           using .C
           using ..M1
           import ..M2
       end
       end # module TestMod42092
Main.TestMod42092

julia> LookingGlass.module_recursive_globals(TestMod42092.A, imported=true, usings=true)
Dict{Tuple{Module, Symbol}, Int64} with 7 entries:
  (Main.TestMod42092.M2, :m2_x)    => 1
  (Main.TestMod42092.A, :y)        => 2
  (Main.TestMod42092.A.C, :y)      => 2
  (Main.TestMod42092.A.B, :secret) => 1
  (Main.TestMod42092.A.C, :x)      => 1
  (Main.TestMod42092.A, :m1_x)     => 1
  (Main.TestMod42092.M1, :m1_x)    => 1
```

NOTE: the `usings=true` option is in PR against Julia 1.8. See: 
https://github.com/JuliaLang/julia/pull/42092